### PR TITLE
Add 'IF NOT EXISTS' to Database creation and set to USE as current Database

### DIFF
--- a/evilwatcher.sql
+++ b/evilwatcher.sql
@@ -19,7 +19,8 @@ SET time_zone = "+00:00";
 --
 -- Banco de Dados: `evilwatcher`
 --
-CREATE DATABASE `evilwatcher`;
+CREATE DATABASE IF NOT EXISTS `evilwatcher`;
+USE `evilwatcher`;
 -- --------------------------------------------------------
 
 --


### PR DESCRIPTION
Added 

``` sql
IF NOT EXISTS
```

to 

``` sql
CREATE DATABASE `evilwatcher`;
```

and added 

``` sql
USE `evilwatcher`;
```

'cause in the first run it's created the DB but displays a #1046 ('No database selected') error and in a second run it's displays a 'Database already exists' error.
